### PR TITLE
Allow for emojis in notifications

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -348,8 +348,8 @@ func invokeTemporaryScript(content string) error {
 	id, _ := uuid.NewV4()
 	file := filepath.Join(os.TempDir(), id.String()+".ps1")
 	defer os.Remove(file)
-	bomUtf8 := []byte{0xEF, 0xBB, 0xBF}
-	out := append(bomUtf8, []byte(content)...)
+	bomUtf16 := []byte("\uFEFF")
+	out := append(bomUtf16, []byte(content)...)
 	err := os.WriteFile(file, out, 0600)
 	if err != nil {
 		return err


### PR DESCRIPTION
Per https://github.com/go-toast/toast/issues/18 and research from @blaedj, using the UTF-16 BOM instead of the current UTF-8 BOM in place should allow us to include emojis in notifications.