### PR TITLE
Don't write temporary ps1 file

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -345,7 +345,8 @@ func Duration(name string) (toastDuration, error) {
 func invokeTemporaryScript(content string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", content)
+	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", "-")
+	cmd.Stdin = strings.NewReader(content)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	if err := cmd.Run(); err != nil {
 		return err

--- a/toast.go
+++ b/toast.go
@@ -3,15 +3,11 @@ package toast
 import (
 	"bytes"
 	"errors"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"text/template"
 
 	"syscall"
-
-	uuid "github.com/nu7hatch/gouuid"
 )
 
 var toastTemplate *template.Template
@@ -345,18 +341,9 @@ func Duration(name string) (toastDuration, error) {
 }
 
 func invokeTemporaryScript(content string) error {
-	id, _ := uuid.NewV4()
-	file := filepath.Join(os.TempDir(), id.String()+".ps1")
-	defer os.Remove(file)
-	bomUtf16 := []byte("\uFEFF")
-	out := append(bomUtf16, []byte(content)...)
-	err := os.WriteFile(file, out, 0600)
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command("PowerShell", "-ExecutionPolicy", "Bypass", "-File", file)
+	cmd := exec.Command("PowerShell", content)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	if err = cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 	return nil

--- a/toast.go
+++ b/toast.go
@@ -2,10 +2,12 @@ package toast
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os/exec"
 	"strings"
 	"text/template"
+	"time"
 
 	"syscall"
 )
@@ -341,7 +343,9 @@ func Duration(name string) (toastDuration, error) {
 }
 
 func invokeTemporaryScript(content string) error {
-	cmd := exec.Command("PowerShell", content)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", content)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	if err := cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
I discovered it wasn't necessary to write out the notification to a temp file before running it, so I'm making that update here. I sent test notifications with emojis to confirm we aren't missing anything by getting rid of the bom-utf16.