### PR TITLE
Fix emoji support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/kolide/toast
 
 go 1.19
-
-require github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
-github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=

--- a/toast.go
+++ b/toast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"text/template"
@@ -345,11 +346,11 @@ func Duration(name string) (toastDuration, error) {
 func invokeTemporaryScript(content string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", "-")
-	cmd.Stdin = strings.NewReader(content)
+
+	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", "-Command", content)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	if err := cmd.Run(); err != nil {
-		return err
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("sending notification with command `%s`: output `%s`, err %w", cmd.String(), string(out), err)
 	}
 	return nil
 }

--- a/toast.go
+++ b/toast.go
@@ -347,6 +347,8 @@ func invokeTemporaryScript(content string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// We have to pass in the script via `-Command <script>` rather than setting cmd.Stdin to avoid
+	// breaking emoji encoding.
 	cmd := exec.CommandContext(ctx, "PowerShell", "-NoProfile", "-NonInteractive", "-Command", content)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
In a previous PR (https://github.com/kolide/toast/pull/3), I updated the powershell command to accept the script via cmd.Stdin. Unfortunately, this does not play nicely with encoding for emojis, and the emojis would show up as Latin characters. I could not figure out a better way to fix this while preserving the usage of cmd.Stdin, so I had to take it out.

I also improved the error message that we return to make troubleshooting easier in the future.