### PR TITLE
ci: upgrade actions, lock dependencies/go packages, add dependabot action checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.19
+          go-version: 1.26
 
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: windows-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.19
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,7 +21,6 @@ jobs:
           go-version: 1.19
 
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
-
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
       - name: Run actionlint
         run: actionlint -color

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.19
       
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           skip-pkg-cache: true
       

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.19
+          go-version: 1.26
       
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,4 +30,6 @@ jobs:
         run: golangci-lint run
       
       - name: govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest; govulncheck ./...
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@19b0bb6a272792b9afa8a6983c3e9b9a1816947f # v1.6.0
+          govulncheck ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: windows-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.19
       
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
           skip-pkg-cache: true
       

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kolide/toast
 
-go 1.19
+go 1.26


### PR DESCRIPTION
[KOL-786](https://1password.atlassian.net/browse/KOL-786)

Still slogging through these :).

GitHub hardening docs [recommend pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). I spot checked the results from a [Claude-generated script](https://gist.github.com/brhoades/e3e3ad40784bc107f7cd2fc9208df4d3) and it looks good.

Changes:
  - Bumped version in advance to avoid dependabot spam.
  - Lock down 2 `go installs` to specific shas. 
  - Configure dependabot for GitHub actions.
  - Lock down the minimal third-party actions to specific version.
  - Bump to go 1.26 to get around actionlint erroring on a 1.25.0 semver.
